### PR TITLE
Create a multimedia note keeper experience

### DIFF
--- a/noteprort/App.js
+++ b/noteprort/App.js
@@ -1,20 +1,18 @@
-import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, Text, View } from 'react-native';
+import 'react-native-gesture-handler';
+import React from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
-export default function App() {
+import { NotesProvider } from './src/context/NotesContext';
+import AppNavigator from './src/navigation/AppNavigator';
+
+const App = () => {
   return (
-    <View style={styles.container}>
-      <Text>Open up App.js to start working on your app!</Text>
-      <StatusBar style="auto" />
-    </View>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NotesProvider>
+        <AppNavigator />
+      </NotesProvider>
+    </GestureHandlerRootView>
   );
-}
+};
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-});
+export default App;

--- a/noteprort/package.json
+++ b/noteprort/package.json
@@ -9,11 +9,22 @@
     "web": "expo start --web"
   },
   "dependencies": {
+    "@expo/vector-icons": "^14.0.2",
+    "@react-navigation/bottom-tabs": "^7.0.10",
+    "@react-navigation/native": "^7.0.10",
+    "@react-navigation/native-stack": "^7.0.10",
+    "expo-av": "~14.0.7",
+    "expo-clipboard": "^6.0.3",
+    "expo-document-picker": "^12.0.3",
+    "expo-image-picker": "~15.0.7",
     "expo": "~54.0.12",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.4",
+    "react-native-gesture-handler": "~2.16.3",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~4.11.1",
     "react-native-web": "^0.21.0"
   },
   "private": true

--- a/noteprort/src/components/AudioPlayer.js
+++ b/noteprort/src/components/AudioPlayer.js
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { Audio } from 'expo-av';
+import { Ionicons } from '@expo/vector-icons';
+
+const AudioPlayer = ({ source }) => {
+  const [sound, setSound] = useState(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [volume, setVolume] = useState(1);
+
+  useEffect(() => {
+    let soundInstance = new Audio.Sound();
+    let isMounted = true;
+
+    (async () => {
+      try {
+        await soundInstance.loadAsync({ uri: source.uri }, { shouldPlay: false, volume: 1 });
+        soundInstance.setOnPlaybackStatusUpdate((status) => {
+          if (!status.isLoaded) return;
+          if (status.didJustFinish) {
+            setIsPlaying(false);
+          } else {
+            setIsPlaying(status.isPlaying);
+          }
+        });
+        if (isMounted) {
+          setSound(soundInstance);
+        }
+      } catch (error) {
+        console.warn('No se pudo cargar el audio', error);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+      soundInstance.unloadAsync();
+      setSound(null);
+      setIsPlaying(false);
+    };
+  }, [source.uri]);
+
+  const togglePlayback = async () => {
+    if (!sound) return;
+    if (isPlaying) {
+      await sound.pauseAsync();
+      setIsPlaying(false);
+    } else {
+      await sound.playAsync();
+      setIsPlaying(true);
+    }
+  };
+
+  const adjustVolume = async (delta) => {
+    if (!sound) return;
+    const nextVolume = Math.min(1, Math.max(0, volume + delta));
+    setVolume(nextVolume);
+    await sound.setVolumeAsync(nextVolume);
+  };
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.info}>
+        <Ionicons name="musical-notes-outline" size={20} color="#0B6E4F" />
+        <Text style={styles.name} numberOfLines={1}>
+          {source.name || 'Clip de audio'}
+        </Text>
+      </View>
+      <View style={styles.controls}>
+        <Pressable style={styles.button} onPress={() => adjustVolume(-0.1)}>
+          <Ionicons name="remove-outline" size={20} color="#0B6E4F" />
+        </Pressable>
+        <Pressable style={styles.playButton} onPress={togglePlayback}>
+          <Ionicons
+            name={isPlaying ? 'pause-circle' : 'play-circle'}
+            size={36}
+            color="#0B6E4F"
+          />
+        </Pressable>
+        <Pressable style={styles.button} onPress={() => adjustVolume(0.1)}>
+          <Ionicons name="add-outline" size={20} color="#0B6E4F" />
+        </Pressable>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 14,
+    backgroundColor: '#E3F2ED',
+    borderRadius: 18,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  info: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  name: {
+    marginLeft: 8,
+    fontSize: 14,
+    color: '#1F2933',
+    flex: 1,
+  },
+  controls: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  button: {
+    padding: 6,
+    borderRadius: 50,
+  },
+  playButton: {
+    marginHorizontal: 18,
+  },
+});
+
+export default AudioPlayer;

--- a/noteprort/src/components/NoteCard.js
+++ b/noteprort/src/components/NoteCard.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+const NoteCard = ({ note, onPress }) => {
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}>
+      <View style={styles.header}>
+        <Text numberOfLines={1} style={styles.title}>
+          {note.title || 'Sin título'}
+        </Text>
+      </View>
+      <Text numberOfLines={4} style={styles.body}>
+        {note.body || 'Empieza a escribir tu idea brillante...'}
+      </Text>
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    flex: 1,
+    minHeight: 180,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 22,
+    padding: 18,
+    margin: 10,
+    shadowColor: '#1f2933',
+    shadowOpacity: 0.08,
+    shadowOffset: { width: 0, height: 8 },
+    shadowRadius: 14,
+    elevation: 4,
+  },
+  cardPressed: {
+    transform: [{ scale: 0.99 }],
+  },
+  header: {
+    marginBottom: 12,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0B1F2A',
+  },
+  body: {
+    fontSize: 14,
+    color: '#48525D',
+    lineHeight: 20,
+  },
+});
+
+export default NoteCard;

--- a/noteprort/src/components/NoteModal.js
+++ b/noteprort/src/components/NoteModal.js
@@ -1,0 +1,342 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  Image,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+
+import TaskList from './TaskList';
+import AudioPlayer from './AudioPlayer';
+
+const createTask = () => ({
+  id: Date.now().toString(),
+  text: '',
+  completed: false,
+});
+
+const NoteModal = ({ visible, note, onClose, onSave, onDelete }) => {
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [tasks, setTasks] = useState([]);
+  const [images, setImages] = useState([]);
+  const [audios, setAudios] = useState([]);
+
+  useEffect(() => {
+    if (note) {
+      setTitle(note.title || '');
+      setBody(note.body || '');
+      setTasks(note.tasks || []);
+      setImages(note.images || []);
+      setAudios(note.audios || []);
+    }
+  }, [note]);
+
+  const handleSave = () => {
+    if (note) {
+      onSave({
+        title,
+        body,
+        tasks,
+        images,
+        audios,
+      });
+    }
+    onClose();
+  };
+
+  const handleDelete = () => {
+    if (!note) return;
+    Alert.alert('Eliminar nota', '¿Quieres borrar esta nota?', [
+      { text: 'Cancelar', style: 'cancel' },
+      {
+        text: 'Eliminar',
+        style: 'destructive',
+        onPress: () => {
+          onDelete?.();
+          onClose();
+        },
+      },
+    ]);
+  };
+
+  const handleCopy = async () => {
+    const tasksText = tasks.map((task) => `${task.completed ? '✔' : '☐'} ${task.text}`).join('\n');
+    const noteText = `${title}\n\n${body}${tasksText ? `\n\n${tasksText}` : ''}`.trim();
+    await Clipboard.setStringAsync(noteText);
+  };
+
+  const handlePaste = async () => {
+    const text = await Clipboard.getStringAsync();
+    if (text) {
+      setBody((prev) => (prev ? `${prev}\n${text}` : text));
+    }
+  };
+
+  const handleAddChecklist = () => {
+    setTasks((prev) => (prev.length ? prev : [createTask()]));
+  };
+
+  const handleAddTask = () => {
+    setTasks((prev) => [...prev, createTask()]);
+  };
+
+  const handleToggleTask = (taskId) => {
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.id === taskId
+          ? {
+              ...task,
+              completed: !task.completed,
+            }
+          : task
+      )
+    );
+  };
+
+  const handleUpdateTask = (taskId, text) => {
+    setTasks((prev) => prev.map((task) => (task.id === taskId ? { ...task, text } : task)));
+  };
+
+  const handleDeleteTask = (taskId) => {
+    setTasks((prev) => prev.filter((task) => task.id !== taskId));
+  };
+
+  const handleCamera = async () => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permiso necesario', 'Necesitamos acceder a la cámara para tomar la foto.');
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      quality: 0.7,
+      base64: false,
+    });
+    if (!result.canceled && result.assets?.length) {
+      const [{ uri }] = result.assets;
+      setImages((prev) => [...prev, { uri, id: Date.now().toString() }]);
+    }
+  };
+
+  const handlePickImage = async () => {
+    const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Permiso necesario', 'Necesitamos acceder a tus imágenes para insertarlas.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({ quality: 0.7 });
+    if (!result.canceled && result.assets?.length) {
+      const [{ uri }] = result.assets;
+      setImages((prev) => [...prev, { uri, id: Date.now().toString() }]);
+    }
+  };
+
+  const handlePickAudio = async () => {
+    try {
+      const result = await DocumentPicker.getDocumentAsync({ type: 'audio/*' });
+      if (result?.assets?.length) {
+        const [asset] = result.assets;
+        setAudios((prev) => [
+          ...prev,
+          { id: Date.now().toString(), uri: asset.uri, name: asset.name },
+        ]);
+      } else if (result.type === 'success') {
+        setAudios((prev) => [
+          ...prev,
+          { id: Date.now().toString(), uri: result.uri, name: result.name },
+        ]);
+      }
+    } catch (error) {
+      console.warn('No se pudo seleccionar el audio', error);
+    }
+  };
+
+  const renderImages = () =>
+    images.map((image) => <Image key={image.id} source={{ uri: image.uri }} style={styles.image} />);
+
+  const renderAudios = () =>
+    audios.map((audio) => <AudioPlayer key={audio.id} source={audio} />);
+
+  return (
+    <Modal visible={visible} animationType="slide" onRequestClose={onClose} presentationStyle="pageSheet">
+      <View style={styles.modalWrapper}>
+        <View style={styles.header}>
+          <Pressable onPress={onClose} style={styles.iconButton}>
+            <Ionicons name="close" size={26} color="#0B1F2A" />
+          </Pressable>
+          <Text style={styles.headerTitle}>Tu nota</Text>
+          <View style={styles.actionsRow}>
+            <Pressable onPress={handleDelete} style={styles.iconButton}>
+              <Ionicons name="trash-bin-outline" size={22} color="#E23E57" />
+            </Pressable>
+            <Pressable onPress={handleSave} style={styles.iconButton}>
+              <Ionicons name="checkmark" size={26} color="#0B6E4F" />
+            </Pressable>
+          </View>
+        </View>
+
+        <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+          <TextInput
+            value={title}
+            onChangeText={setTitle}
+            placeholder="Título"
+            style={styles.titleInput}
+          />
+          <View style={styles.bodyHeader}>
+            <Text style={styles.sectionTitle}>Contenido</Text>
+            <Pressable onPress={handlePaste} style={styles.pasteButton}>
+              <Ionicons name="clipboard-outline" size={18} color="#0B6E4F" />
+              <Text style={styles.pasteText}>Pegar</Text>
+            </Pressable>
+          </View>
+          <TextInput
+            value={body}
+            onChangeText={setBody}
+            placeholder="Escribe lo que quieras recordar..."
+            style={styles.bodyInput}
+            multiline
+          />
+          {renderImages()}
+          {renderAudios()}
+          {tasks.length > 0 && (
+            <TaskList
+              tasks={tasks}
+              onToggleTask={handleToggleTask}
+              onUpdateTask={handleUpdateTask}
+              onDeleteTask={handleDeleteTask}
+              onAddTask={handleAddTask}
+            />
+          )}
+        </ScrollView>
+
+        <View style={styles.toolbar}>
+          <ActionButton icon="copy-outline" label="Copiar" onPress={handleCopy} />
+          <ActionButton icon="camera-outline" label="Cámara" onPress={handleCamera} />
+          <ActionButton icon="image-outline" label="Galería" onPress={handlePickImage} />
+          <ActionButton icon="musical-notes-outline" label="Audio" onPress={handlePickAudio} />
+          <ActionButton icon="checkbox-outline" label="Checklist" onPress={handleAddChecklist} />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const ActionButton = ({ icon, label, onPress }) => (
+  <Pressable onPress={onPress} style={styles.actionButton}>
+    <Ionicons name={icon} size={22} color="#0B6E4F" />
+    <Text style={styles.actionLabel}>{label}</Text>
+  </Pressable>
+);
+
+const styles = StyleSheet.create({
+  modalWrapper: {
+    flex: 1,
+    backgroundColor: '#F3F3F4',
+    paddingHorizontal: 20,
+    paddingTop: 40,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 16,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#0B1F2A',
+  },
+  iconButton: {
+    padding: 8,
+  },
+  actionsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  scrollContent: {
+    paddingBottom: 120,
+  },
+  titleInput: {
+    fontSize: 20,
+    fontWeight: '600',
+    color: '#0B1F2A',
+    marginBottom: 16,
+  },
+  bodyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#48525D',
+  },
+  pasteButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#E3F2ED',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  pasteText: {
+    marginLeft: 4,
+    color: '#0B6E4F',
+    fontWeight: '600',
+  },
+  bodyInput: {
+    marginTop: 12,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 18,
+    minHeight: 160,
+    padding: 16,
+    textAlignVertical: 'top',
+    fontSize: 15,
+    color: '#1F2933',
+  },
+  image: {
+    marginTop: 14,
+    borderRadius: 18,
+    width: '100%',
+    height: 200,
+  },
+  toolbar: {
+    position: 'absolute',
+    bottom: 20,
+    left: 20,
+    right: 20,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 28,
+    padding: 14,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    shadowColor: '#1f2933',
+    shadowOpacity: 0.12,
+    shadowRadius: 18,
+    shadowOffset: { width: 0, height: 12 },
+    elevation: 8,
+  },
+  actionButton: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  actionLabel: {
+    marginTop: 4,
+    fontSize: 12,
+    color: '#48525D',
+    textAlign: 'center',
+  },
+});
+
+export default NoteModal;

--- a/noteprort/src/components/TaskList.js
+++ b/noteprort/src/components/TaskList.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+const TaskList = ({ tasks, onToggleTask, onUpdateTask, onDeleteTask, onAddTask }) => {
+  const renderItem = ({ item }) => (
+    <View style={styles.row}>
+      <Pressable onPress={() => onToggleTask(item.id)} style={styles.checkbox}>
+        <Ionicons
+          name={item.completed ? 'checkbox' : 'square-outline'}
+          size={22}
+          color={item.completed ? '#0B6E4F' : '#7B8794'}
+        />
+      </Pressable>
+      <TextInput
+        value={item.text}
+        onChangeText={(text) => onUpdateTask(item.id, text)}
+        placeholder="Nueva tarea"
+        style={[styles.input, item.completed && styles.completedInput]}
+      />
+      <Pressable onPress={() => onDeleteTask(item.id)} style={styles.deleteButton}>
+        <Ionicons name="trash-outline" size={18} color="#E23E57" />
+      </Pressable>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.heading}>Lista de tareas</Text>
+      {/* Usamos FlatList para renderizar eficientemente la colección de tareas. Nos permite agregar, modificar o eliminar elementos del array y solo se vuelven a pintar los ítems que cambian, lo que mantiene la UI fluida incluso con muchas tareas. */}
+      <FlatList
+        data={tasks}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        ListEmptyComponent={<Text style={styles.empty}>Agrega tu primera tarea.</Text>}
+      />
+      <Pressable style={styles.addTask} onPress={onAddTask}>
+        <Ionicons name="add-circle-outline" size={20} color="#0B6E4F" />
+        <Text style={styles.addTaskText}>Agregar tarea</Text>
+      </Pressable>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 16,
+    backgroundColor: '#F2F7F5',
+    borderRadius: 18,
+    padding: 16,
+  },
+  heading: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: '#0B1F2A',
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 12,
+  },
+  checkbox: {
+    marginRight: 8,
+  },
+  input: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    fontSize: 15,
+    color: '#1F2933',
+  },
+  completedInput: {
+    textDecorationLine: 'line-through',
+    color: '#7B8794',
+  },
+  deleteButton: {
+    marginLeft: 8,
+    padding: 4,
+  },
+  empty: {
+    color: '#7B8794',
+    textAlign: 'center',
+    fontStyle: 'italic',
+  },
+  addTask: {
+    marginTop: 6,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addTaskText: {
+    marginLeft: 6,
+    color: '#0B6E4F',
+    fontWeight: '600',
+  },
+});
+
+export default TaskList;

--- a/noteprort/src/context/NotesContext.js
+++ b/noteprort/src/context/NotesContext.js
@@ -1,0 +1,52 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+const NotesContext = createContext();
+
+const createEmptyNote = () => ({
+  id: Date.now().toString(),
+  title: '',
+  body: '',
+  tasks: [],
+  images: [],
+  audios: [],
+});
+
+export const NotesProvider = ({ children }) => {
+  const [notes, setNotes] = useState([]);
+
+  const addNote = () => {
+    const newNote = createEmptyNote();
+    setNotes((prev) => [newNote, ...prev]);
+    return newNote;
+  };
+
+  const updateNote = (id, payload) => {
+    setNotes((prev) => prev.map((note) => (note.id === id ? { ...note, ...payload } : note)));
+  };
+
+  const deleteNote = (id) => {
+    setNotes((prev) => prev.filter((note) => note.id !== id));
+  };
+
+  const value = useMemo(
+    () => ({
+      notes,
+      addNote,
+      updateNote,
+      deleteNote,
+    }),
+    [notes]
+  );
+
+  return <NotesContext.Provider value={value}>{children}</NotesContext.Provider>;
+};
+
+export const useNotes = () => {
+  const context = useContext(NotesContext);
+  if (!context) {
+    throw new Error('useNotes must be used inside NotesProvider');
+  }
+  return context;
+};
+
+export const initializeEmptyNote = createEmptyNote;

--- a/noteprort/src/navigation/AppNavigator.js
+++ b/noteprort/src/navigation/AppNavigator.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { NavigationContainer, DefaultTheme } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { Ionicons } from '@expo/vector-icons';
+
+import NotesScreen from '../screens/NotesScreen';
+import ClipboardScreen from '../screens/ClipboardScreen';
+
+const Tab = createBottomTabNavigator();
+const Stack = createNativeStackNavigator();
+
+const NotesStack = () => (
+  <Stack.Navigator>
+    <Stack.Screen
+      name="Notas"
+      component={NotesScreen}
+      options={{ headerShown: false }}
+    />
+  </Stack.Navigator>
+);
+
+const AppTheme = {
+  ...DefaultTheme,
+  colors: {
+    ...DefaultTheme.colors,
+    background: '#F3F3F4',
+  },
+};
+
+const AppNavigator = () => (
+  <NavigationContainer theme={AppTheme}>
+    <Tab.Navigator
+      screenOptions={({ route }) => ({
+        tabBarIcon: ({ color, size }) => {
+          const iconMap = {
+            Inicio: 'grid-outline',
+            Portapapeles: 'clipboard-outline',
+          };
+          const name = iconMap[route.name] || 'ellipse-outline';
+          return <Ionicons name={name} size={size} color={color} />;
+        },
+        tabBarActiveTintColor: '#0B6E4F',
+        tabBarInactiveTintColor: '#92A1B0',
+        headerShown: false,
+        tabBarStyle: {
+          backgroundColor: '#fff',
+          borderTopWidth: 0,
+          elevation: 8,
+        },
+      })}
+    >
+      <Tab.Screen name="Inicio" component={NotesStack} />
+      <Tab.Screen name="Portapapeles" component={ClipboardScreen} />
+    </Tab.Navigator>
+  </NavigationContainer>
+);
+
+export default AppNavigator;

--- a/noteprort/src/screens/ClipboardScreen.js
+++ b/noteprort/src/screens/ClipboardScreen.js
@@ -1,0 +1,223 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import * as Clipboard from 'expo-clipboard';
+
+const ClipboardScreen = () => {
+  const [text, setText] = useState('');
+  const [history, setHistory] = useState([]);
+
+  const refreshHistory = async () => {
+    try {
+      const result = await Clipboard.getStringHistoryAsync();
+      if (Array.isArray(result?.values)) {
+        setHistory(result.values);
+      }
+    } catch (error) {
+      // Algunos dispositivos no exponen historial. Avisamos una vez.
+      console.warn('Historial no disponible', error);
+    }
+  };
+
+  useEffect(() => {
+    refreshHistory();
+  }, []);
+
+  const handleCopy = async () => {
+    await Clipboard.setStringAsync(text);
+    await refreshHistory();
+  };
+
+  const handleCut = async () => {
+    await Clipboard.setStringAsync(text);
+    setText('');
+    await refreshHistory();
+  };
+
+  const handlePaste = async () => {
+    const value = await Clipboard.getStringAsync();
+    if (value) {
+      setText((prev) => (prev ? `${prev}\n${value}` : value));
+    } else {
+      Alert.alert('Portapapeles vacío', 'No encontramos texto para pegar.');
+    }
+  };
+
+  const renderHistoryItem = ({ item, index }) => (
+    <Pressable
+      style={styles.historyItem}
+      onPress={() => setText((prev) => (prev ? `${prev}\n${item}` : item))}
+    >
+      <Text style={styles.historyIndex}>{index + 1}.</Text>
+      <Text style={styles.historyText} numberOfLines={2}>
+        {item}
+      </Text>
+    </Pressable>
+  );
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.container}
+      >
+        <Text style={styles.heading}>Centro de portapapeles</Text>
+        <Text style={styles.subheading}>
+          Copia, corta, pega y revisa el historial de fragmentos para reutilizarlos en tus notas.
+        </Text>
+        <View style={styles.inputContainer}>
+          <TextInput
+            value={text}
+            onChangeText={setText}
+            placeholder="Escribe algo aquí..."
+            multiline
+            style={styles.input}
+          />
+        </View>
+        <View style={styles.buttonRow}>
+          <ClipboardButton icon="copy-outline" label="Copiar" onPress={handleCopy} />
+          <ClipboardButton icon="cut-outline" label="Cortar" onPress={handleCut} />
+          <ClipboardButton icon="clipboard-outline" label="Pegar" onPress={handlePaste} />
+        </View>
+        <View style={styles.historyHeader}>
+          <Text style={styles.historyTitle}>Historial</Text>
+          <Pressable onPress={refreshHistory} style={styles.refreshButton}>
+            <Ionicons name="refresh" size={18} color="#0B6E4F" />
+            <Text style={styles.refreshText}>Actualizar</Text>
+          </Pressable>
+        </View>
+        <FlatList
+          data={history}
+          keyExtractor={(item, index) => `${item}-${index}`}
+          renderItem={renderHistoryItem}
+          ListEmptyComponent={
+            <Text style={styles.emptyHistory}>El historial aparecerá aquí cuando copies algo.</Text>
+          }
+        />
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const ClipboardButton = ({ icon, label, onPress }) => (
+  <Pressable onPress={onPress} style={styles.clipboardButton}>
+    <Ionicons name={icon} size={20} color="#0B6E4F" />
+    <Text style={styles.clipboardLabel}>{label}</Text>
+  </Pressable>
+);
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#F3F3F4',
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  heading: {
+    fontSize: 26,
+    fontWeight: '700',
+    color: '#0B1F2A',
+  },
+  subheading: {
+    marginTop: 6,
+    color: '#6B7A8F',
+    fontSize: 15,
+    marginBottom: 16,
+  },
+  inputContainer: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 20,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#1f2933',
+    shadowOpacity: 0.05,
+    shadowOffset: { width: 0, height: 6 },
+    shadowRadius: 12,
+  },
+  input: {
+    minHeight: 120,
+    textAlignVertical: 'top',
+    fontSize: 16,
+    color: '#1F2933',
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 20,
+  },
+  clipboardButton: {
+    flex: 1,
+    backgroundColor: '#E3F2ED',
+    borderRadius: 18,
+    paddingVertical: 12,
+    marginHorizontal: 4,
+    alignItems: 'center',
+  },
+  clipboardLabel: {
+    marginTop: 4,
+    color: '#0B6E4F',
+    fontWeight: '600',
+  },
+  historyHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  historyTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#0B1F2A',
+  },
+  refreshButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 14,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+  },
+  refreshText: {
+    marginLeft: 6,
+    color: '#0B6E4F',
+    fontWeight: '600',
+  },
+  historyItem: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 12,
+    marginBottom: 10,
+  },
+  historyIndex: {
+    fontWeight: '600',
+    color: '#0B6E4F',
+    marginRight: 8,
+  },
+  historyText: {
+    flex: 1,
+    color: '#48525D',
+  },
+  emptyHistory: {
+    textAlign: 'center',
+    color: '#92A1B0',
+    marginTop: 20,
+  },
+});
+
+export default ClipboardScreen;

--- a/noteprort/src/screens/NotesScreen.js
+++ b/noteprort/src/screens/NotesScreen.js
@@ -1,0 +1,143 @@
+import React, { useMemo, useState } from 'react';
+import { FlatList, Pressable, SafeAreaView, StatusBar, StyleSheet, Text, View } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+
+import NoteCard from '../components/NoteCard';
+import NoteModal from '../components/NoteModal';
+import { useNotes } from '../context/NotesContext';
+
+const NotesScreen = () => {
+  const { notes, addNote, updateNote, deleteNote } = useNotes();
+  const [selectedNoteId, setSelectedNoteId] = useState(null);
+
+  const selectedNote = useMemo(
+    () => notes.find((note) => note.id === selectedNoteId) || null,
+    [notes, selectedNoteId]
+  );
+
+  const handleAddNote = () => {
+    const newNote = addNote();
+    setSelectedNoteId(newNote.id);
+  };
+
+  const handleOpenNote = (noteId) => {
+    setSelectedNoteId(noteId);
+  };
+
+  const handleClose = () => {
+    setSelectedNoteId(null);
+  };
+
+  const handleSave = (payload) => {
+    if (selectedNoteId) {
+      updateNote(selectedNoteId, payload);
+    }
+  };
+
+  const handleDelete = () => {
+    if (selectedNoteId) {
+      deleteNote(selectedNoteId);
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <StatusBar barStyle="dark-content" />
+      <View style={styles.container}>
+        <Text style={styles.heading}>Notas relucientes</Text>
+        <Text style={styles.subheading}>
+          Crea recordatorios visuales y auditivos en segundos. Todo organizado en cuadrículas minimalistas.
+        </Text>
+        <FlatList
+          data={notes}
+          keyExtractor={(item) => item.id}
+          numColumns={2}
+          renderItem={({ item }) => <NoteCard note={item} onPress={() => handleOpenNote(item.id)} />}
+          contentContainerStyle={notes.length ? styles.listContent : styles.emptyContainer}
+          ListEmptyComponent={
+            <View style={styles.emptyState}>
+              <Ionicons name="sparkles-outline" size={42} color="#92A1B0" />
+              <Text style={styles.emptyTitle}>Sin notas todavía</Text>
+              <Text style={styles.emptySubtitle}>Toca el botón + para crear tu primera idea brillante.</Text>
+            </View>
+          }
+        />
+        <Pressable style={styles.fab} onPress={handleAddNote}>
+          <Ionicons name="add" size={30} color="#fff" />
+        </Pressable>
+      </View>
+      <NoteModal
+        visible={!!selectedNote}
+        note={selectedNote}
+        onClose={handleClose}
+        onSave={handleSave}
+        onDelete={handleDelete}
+      />
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#F3F3F4',
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  heading: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#0B1F2A',
+  },
+  subheading: {
+    marginTop: 6,
+    color: '#6B7A8F',
+    fontSize: 15,
+    marginBottom: 20,
+  },
+  listContent: {
+    paddingBottom: 120,
+  },
+  emptyContainer: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingBottom: 120,
+  },
+  emptyState: {
+    alignItems: 'center',
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    marginTop: 12,
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#48525D',
+  },
+  emptySubtitle: {
+    marginTop: 6,
+    textAlign: 'center',
+    color: '#92A1B0',
+  },
+  fab: {
+    position: 'absolute',
+    bottom: 30,
+    right: 24,
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: '#0B6E4F',
+    justifyContent: 'center',
+    alignItems: 'center',
+    shadowColor: '#0B6E4F',
+    shadowOpacity: 0.3,
+    shadowRadius: 10,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 10,
+  },
+});
+
+export default NotesScreen;


### PR DESCRIPTION
## Summary
- replace the starter component with a navigation shell that provides bottom tabs for notes and clipboard utilities
- implement a Keep-inspired notes workspace with modal editing, media attachments, checklist management via FlatList, and clipboard shortcuts
- add a dedicated clipboard manager screen and supporting dependencies for navigation, media capture, and audio playback

## Testing
- `npm install` *(fails: registry returned 403 when installing scoped Expo packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e3b8465c80832d8a2ab8f5562eecc9